### PR TITLE
Upgrades to 1.3 and I dropped dependency of Touch in ART.Button

### DIFF
--- a/Source/ART.Button.js
+++ b/Source/ART.Button.js
@@ -2,7 +2,7 @@
 ---
 name: ART.Button
 description: Base Button Class
-requires: [UI.Sheet, UI.Widget, ART.Widget, Core/Class, Core/Element, Core/Element.Events, ART/ART.Rectangle, ART/ART.Font]
+requires: [UI.Sheet, UI.Widget, ART.Widget, Core/Class, Core/Element, Core/Element.Event, ART/ART.Rectangle, ART/ART.Font]
 provides: ART.Button
 ...
 */
@@ -75,24 +75,20 @@ var Button = ART.Button = new Class({
 			}
 
 		});
-		
-		this.touch = new Touch(this.element);
-		
-		this.touch.addEvents({
+
+		this.bound = {
 			
-			start: function(){
+			mousedown: function(){
 				self.activate();
 			},
 			
-			end: function(){
-				self.deactivate();
-			},
-			
-			cancel: function(){
+			mouseup: function(){
 				if (self.deactivate()) self.fireEvent('press');
 			}
 		
-		});
+		};
+
+		this.attach();
 
 	},
 	
@@ -140,14 +136,22 @@ var Button = ART.Button = new Class({
 	
 	enable: function(){
 		if (!this.parent()) return false;
-		this.touch.attach();
+		this.attach();
 		return true;
 	},
 	
 	disable: function(){
 		if (!this.parent()) return false;
-		this.touch.detach();
+		this.detach();
 		return true;
+	},
+
+	attach: function(){
+		this.element.addEvents(this.bound);
+	},
+
+	detach: function(){
+		this.element.removeEvents(this.bound);
 	}
 	
 });

--- a/Source/ART.Button.js
+++ b/Source/ART.Button.js
@@ -124,11 +124,11 @@ var Button = ART.Button = new Class({
 			this.textLayer.translate(cs.padding[3], cs.padding[0]);
 		}
 		
-		if (sheet.shadowColor) this.shadowLayer.fill.apply(this.shadowLayer, $splat(sheet.shadowColor));
-		if (sheet.borderColor) this.borderLayer.fill.apply(this.borderLayer, $splat(sheet.borderColor));
-		if (sheet.reflectionColor) this.reflectionLayer.fill.apply(this.reflectionLayer, $splat(sheet.reflectionColor));
-		if (sheet.backgroundColor) this.backgroundLayer.fill.apply(this.backgroundLayer, $splat(sheet.backgroundColor));
-		if (sheet.fontColor) this.textLayer.fill.apply(this.textLayer, $splat(sheet.fontColor));
+		if (sheet.shadowColor) this.shadowLayer.fill.apply(this.shadowLayer, Array.from(sheet.shadowColor));
+		if (sheet.borderColor) this.borderLayer.fill.apply(this.borderLayer, Array.from(sheet.borderColor));
+		if (sheet.reflectionColor) this.reflectionLayer.fill.apply(this.reflectionLayer, Array.from(sheet.reflectionColor));
+		if (sheet.backgroundColor) this.backgroundLayer.fill.apply(this.backgroundLayer, Array.from(sheet.backgroundColor));
+		if (sheet.fontColor) this.textLayer.fill.apply(this.textLayer, Array.from(sheet.fontColor));
 		
 		return this;
 		

--- a/Source/ART.Widget.js
+++ b/Source/ART.Widget.js
@@ -61,7 +61,7 @@ var Widget = ART.Widget = new Class({
 	},
 	
 	draw: function(newSheet){
-		var sheet = $merge(this.diffSheet(), newSheet || {});
+		var sheet = Object.merge(this.diffSheet(), newSheet || {});
 		for (var property in sheet) this.currentSheet[property] = sheet[property];
 		return sheet;
 	},

--- a/Source/ART.Widget.js
+++ b/Source/ART.Widget.js
@@ -2,7 +2,7 @@
 ---
 name: ART.Widget
 description: ART Widget Class
-requires: [UI.Widget, Core/Class, Core/Element, Core/Element.Events, ART/ART.Base]
+requires: [UI.Widget, Core/Class, Core/Element, Core/Element.Event, ART/ART.Base]
 provides: ART.Widget
 ...
 */

--- a/Source/UI.Sheet.js
+++ b/Source/UI.Sheet.js
@@ -76,7 +76,7 @@ Sheet.lookup = function(selector){
 				if (containsAll(selector[j], rule.selector[i])) break;
 			}
 		}
-		$mixin(style, rule.style);
+		Object.merge(style, rule.style);
 	});
 	return style;
 };


### PR DESCRIPTION
Fixed a couple of $ function use to 1.3.

The drop of the Touch dependency is a bit controversial. I was thinking that could go for a ART.Button.Drag or as a dependency injection in the options of the Button instantiation. What do you think?
